### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/__pycache__
 .vscode
-test-reports/*
+test-reports


### PR DESCRIPTION
added test-reports directory to gitignore, given that pestcontrol now creates the directory if needed.